### PR TITLE
change grad_cam initialization from np.ones to np.zeros

### DIFF
--- a/saliency/grad_cam.py
+++ b/saliency/grad_cam.py
@@ -61,7 +61,7 @@ class GradCam(SaliencyMask):
         grad = grad[0]
 
         weights = np.mean(grad, axis=(0,1))
-        grad_cam = np.ones(output.shape[0:2], dtype=np.float32)
+        grad_cam = np.zeros(output.shape[0:2], dtype=np.float32)
 
         # weighted average
         for i, w in enumerate(weights):


### PR DESCRIPTION
Per discussion with @nalinimsingh; this should be np.zeros (it won't change the visualization qualitatively, but the numerical values with be shifted by -1 now and properly centered at 0).