### PR TITLE
Allow batching for integrated gradient and multithreading for SmoothGrad

### DIFF
--- a/saliency/base.py
+++ b/saliency/base.py
@@ -15,6 +15,7 @@
 """Utilities to compute SaliencyMasks."""
 import numpy as np
 import tensorflow as tf
+from multiprocessing import dummy as multiprocessing
 
 class SaliencyMask(object):
   """Base class for saliency masks. Alone, this class doesn't do anything."""
@@ -25,17 +26,10 @@ class SaliencyMask(object):
       graph: The TensorFlow graph to evaluate masks on.
       session: The current TensorFlow session.
       y: The output tensor to compute the SaliencyMask against. This tensor
-          should be of size 1.
+          should have the same first dimension (batch size) as x.
       x: The input tensor to compute the SaliencyMask against. The outer
           dimension should be the batch size.
     """
-
-    # y must be of size one, otherwise the gradient we get from tf.gradients
-    # will be summed over all ys.
-    size = 1
-    for shape in y.shape:
-      size *= shape
-    assert size == 1
 
     self.graph = graph
     self.session = session
@@ -53,7 +47,7 @@ class SaliencyMask(object):
 
   def GetSmoothedMask(
       self, x_value, feed_dict={}, stdev_spread=.15, nsamples=25,
-      magnitude=True, **kwargs):
+      magnitude=True, num_threads=1, **kwargs):
     """Returns a mask that is smoothed with the SmoothGrad method.
 
     Args:
@@ -67,15 +61,16 @@ class SaliencyMask(object):
     """
     stdev = stdev_spread * (np.max(x_value) - np.min(x_value))
 
-    total_gradients = np.zeros_like(x_value)
-    for i in range(nsamples):
+    def single_mask(i):
       noise = np.random.normal(0, stdev, x_value.shape)
       x_plus_noise = x_value + noise
-      grad = self.GetMask(x_plus_noise, feed_dict, **kwargs)
-      if magnitude:
-        total_gradients += (grad * grad)
-      else:
-        total_gradients += grad
+      return self.GetMask(x_plus_noise, feed_dict, **kwargs)
+
+    pool = multiprocessing.Pool(num_threads)
+    grads = np.array(pool.map(single_mask, range(nsamples)))
+    if magnitude:
+      grads = grads * grads
+    total_gradients = np.sum(grads, axis=0)
 
     return total_gradients / nsamples
 

--- a/saliency/base.py
+++ b/saliency/base.py
@@ -47,7 +47,7 @@ class SaliencyMask(object):
 
   def GetSmoothedMask(
       self, x_value, feed_dict={}, stdev_spread=.15, nsamples=25,
-      magnitude=True, num_threads=1, **kwargs):
+      magnitude=True, num_threads=None, **kwargs):
     """Returns a mask that is smoothed with the SmoothGrad method.
 
     Args:

--- a/saliency/integrated_gradients.py
+++ b/saliency/integrated_gradients.py
@@ -39,12 +39,11 @@ class IntegratedGradients(GradientSaliency):
 
     x_diff = x_value - x_baseline
 
-    total_gradients = np.zeros_like(x_value)
-
+    x_val = []
     for alpha in np.linspace(0, 1, x_steps):
-      x_step = x_baseline + alpha * x_diff
-
-      total_gradients += super(IntegratedGradients, self).GetMask(
-          x_step, feed_dict)
-
+      x_val.append(x_baseline + alpha * x_diff)
+    feed_dict[self.x] = x_val
+    y_val, dy_dx_val = self.session.run([self.y, self.gradients_node],
+                                        feed_dict)
+    total_gradients = np.sum(dy_dx_val, axis=0)
     return total_gradients * x_diff / x_steps

--- a/saliency/integrated_gradients_test.py
+++ b/saliency/integrated_gradients_test.py
@@ -45,7 +45,7 @@ class IntegratedGradientsTest(googletest.TestCase):
         expected_val = y_input_val[0] - y_baseline_val[0]
 
         # Calculate the integrated gradients attribution of the input.
-        ig = integrated_gradients.IntegratedGradients(graph, sess, y[0], x)
+        ig = integrated_gradients.IntegratedGradients(graph, sess, y, x)
         mask = ig.GetMask(x_value=x_input_val[0], feed_dict={},
                           x_baseline=x_baseline_val[0], x_steps=1000)
 


### PR DESCRIPTION
We can enable batching if input x and logit y have the same batch size, similar to the answer here: https://stackoverflow.com/questions/51858970/tf-gradients-sums-over-ys-does-it