### PR TITLE
Use markdown as long description content type to properly render desc…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
 
     description='Saliency methods for TensorFlow',
     long_description=long_description,
+    long_description_content_type='text/markdown',
 
     # The project's main homepage.
     url='https://github.com/pair-code/saliency',


### PR DESCRIPTION
…ription on Pypi.

Need this to properly render long description on Pypi. Otherwise upload is rejected.