### PR TITLE
Revert "Allow batching for integrated gradient and multithreading for SmoothGrad"

### DIFF
--- a/saliency/integrated_gradients.py
+++ b/saliency/integrated_gradients.py
@@ -39,11 +39,12 @@ class IntegratedGradients(GradientSaliency):
 
     x_diff = x_value - x_baseline
 
-    x_val = []
+    total_gradients = np.zeros_like(x_value)
+
     for alpha in np.linspace(0, 1, x_steps):
-      x_val.append(x_baseline + alpha * x_diff)
-    feed_dict[self.x] = x_val
-    y_val, dy_dx_val = self.session.run([self.y, self.gradients_node],
-                                        feed_dict)
-    total_gradients = np.sum(dy_dx_val, axis=0)
+      x_step = x_baseline + alpha * x_diff
+
+      total_gradients += super(IntegratedGradients, self).GetMask(
+          x_step, feed_dict)
+
     return total_gradients * x_diff / x_steps

--- a/saliency/integrated_gradients_test.py
+++ b/saliency/integrated_gradients_test.py
@@ -45,7 +45,7 @@ class IntegratedGradientsTest(googletest.TestCase):
         expected_val = y_input_val[0] - y_baseline_val[0]
 
         # Calculate the integrated gradients attribution of the input.
-        ig = integrated_gradients.IntegratedGradients(graph, sess, y, x)
+        ig = integrated_gradients.IntegratedGradients(graph, sess, y[0], x)
         mask = ig.GetMask(x_value=x_input_val[0], feed_dict={},
                           x_baseline=x_baseline_val[0], x_steps=1000)
 


### PR DESCRIPTION
Reverts PAIR-code/saliency#20
Integrated gradients is producing incorrect results after this PR.
Verified that the Examples.ipynb notebook IG results look different:

New results:
![ig_broken](https://user-images.githubusercontent.com/6536229/61335354-389db400-a7fb-11e9-8c26-75532cdaa551.png)

Old results:
![old_ig](https://user-images.githubusercontent.com/6536229/61335458-7f8ba980-a7fb-11e9-93d0-373c3ff6ec2f.png)

Verified that the IG attributions no longer sum to input_confidence - baseline_confidence. The IG sum seems to scale with steps now (e.g. if steps=100 and IG_sum=1.0, when steps is set to 200, IG_sum becomes 0.5.).
