### PR TITLE
Allow a caller to provide pre-calculated base attribution to XRAI.

### DIFF
--- a/saliency/xrai_test.py
+++ b/saliency/xrai_test.py
@@ -180,6 +180,32 @@ class XraiTest(googletest.TestCase):
     self.assertTrue(np.array_equal(baseline_2, calls[1][2]['x_baseline']),
                     msg='IG was called with incorrect baseline.')
 
+  def testBaseAttribution(self):
+    base_attribution = np.random.rand(IMAGE_SIZE, IMAGE_SIZE, 3)
+
+    # Calculate XRAI attribution using GetMask(...) method.
+    heatmap = self.xrai.GetMask(x_value=self.input_image,
+                                base_attribution=base_attribution)
+    # Verify the result.
+    self.assertFalse(np.array_equal(base_attribution.max(axis=2), heatmap))
+    self.assertAlmostEqual(base_attribution.max(axis=2).sum(), heatmap.sum())
+
+    # Verify that the XRAI object didn't called Integrated Gradients.
+    calls = self.mock_ig_instance.method_calls
+    self.assertEqual(0, len(calls),
+                     'XRAI should not call Integrated Gradients.')
+
+  def testBaseAttributionMismatchedShape(self):
+    # Create base_attribution that shape doesn't match the input.
+    base_attribution = np.random.rand(IMAGE_SIZE, IMAGE_SIZE + 1, 3)
+
+    # Verify that the exception was raised.
+    with self.assertRaisesRegexp(ValueError, 'The base attribution shape '
+                                             'should'):
+      # Calling GetMask(...) should result in exception.
+      self.xrai.GetMask(x_value=self.input_image,
+                        base_attribution=base_attribution)
+
   def _assert_xrai_correctness(self, xrai_out, is_flatten_segments):
     """Performs general XRAIOutput verification that is applicable for all
        XRAI results.

--- a/saliency/xrai_test.py
+++ b/saliency/xrai_test.py
@@ -186,8 +186,12 @@ class XraiTest(googletest.TestCase):
     # Calculate XRAI attribution using GetMask(...) method.
     heatmap = self.xrai.GetMask(x_value=self.input_image,
                                 base_attribution=base_attribution)
-    # Verify the result.
+    # Make sure that the GetMask() method doesn't return the same attribution
+    # that was passed to it.
     self.assertFalse(np.array_equal(base_attribution.max(axis=2), heatmap))
+    # The sum of XRAI attribution should be equal to the sum of the underlying
+    # base attribution. Internally the attribution that is used by XRAI is
+    # the max over color channels.
     self.assertAlmostEqual(base_attribution.max(axis=2).sum(), heatmap.sum())
 
     # Verify that the XRAI object didn't called Integrated Gradients.


### PR DESCRIPTION
If a client has pre-calculated IG attribution, the client should be able to pass it to XRAI without XRAI calculating the attribution the second time. This change allows the caller to pass pre-calculated attribution to XRAI.