### PR TITLE
Bump version to 0.0.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.0.4',
+    version='0.0.5',
 
     description='Saliency methods for TensorFlow',
     long_description=long_description,


### PR DESCRIPTION
Bumping version for pip. Major changes since 0.0.4:

* Added support to supply your own attributions for XRAI.