### PR TITLE
Update grad_cam resize method with TF V2.

### DIFF
--- a/saliency/grad_cam.py
+++ b/saliency/grad_cam.py
@@ -74,7 +74,7 @@ class GradCam(SaliencyMask):
         if should_resize:
             grad_cam = grad_cam / np.max(grad_cam) # values need to be [0,1] to be resized
             with self.graph.as_default():
-                grad_cam = np.squeeze(tf.image.resize_bilinear(
+                grad_cam = np.squeeze(tf.compat.v2.image.resize(
                     np.expand_dims(np.expand_dims(grad_cam, 0), 3), 
                     x_value.shape[:2]).eval(session=self.session))
 


### PR DESCRIPTION
Use TF V2 resize for GradCam, because TF V1 bilinear resize have artifact of shifting images.

https://github.com/tensorflow/tensorflow/issues/6720
https://hackernoon.com/how-tensorflows-tf-image-resize-stole-60-days-of-my-life-aba5eb093f35