### PR TITLE
Enable half_pixel_centers=True for resizing GradCAM heatmap.

### DIFF
--- a/saliency/grad_cam.py
+++ b/saliency/grad_cam.py
@@ -76,7 +76,7 @@ class GradCam(SaliencyMask):
             with self.graph.as_default():
                 grad_cam = np.squeeze(tf.image.resize_bilinear(
                     np.expand_dims(np.expand_dims(grad_cam, 0), 3),
-                    x_value.shape[:2]).eval(session=self.session))
+                    x_value.shape[:2], half_pixel_centers=True).eval(session=self.session))
 
         # convert grayscale to 3-D
         if three_dims:


### PR DESCRIPTION
Enable half_pixel_centers=True for resizing after GradCAM to avoid shift by a half pixel.

It will make the behavior compatible to tf.image.resize in tf2. See
https://github.com/tensorflow/tensorflow/blob/v2.4.1/tensorflow/python/ops/image_ops_impl.py#L1623

Alternatively, this is equivalent to changing tf.image.resize_bilinear to tf.compat.v2.image.resize, or to tf.image.resize and change tf import to v2.

Note that only changing this to tf.image.resize won't solve the bug, because in tf1, it doesn't enable half_pixel_centers.
https://github.com/tensorflow/tensorflow/blob/v2.4.1/tensorflow/python/ops/image_ops_impl.py#L1447