### PR TITLE
Bump version to 0.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.0.6',
+    version='0.1.0',
 
     description='Saliency methods for TensorFlow',
     long_description=long_description,
@@ -57,6 +57,9 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 
     # What does your project relate to?


### PR DESCRIPTION
We are updating the version as this is the first version after a major overhaul which implements saliency methods in a framework agnostic manner, and TF1 compatibility has been moved to a separate subpackage. Concretely:

- Upgrades pip version to 0.1.0
- Lists Python 3.5-3.8 as compatible.

