### PR TITLE
Bump version to 0.1.1 to fix pip packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.1.0',
+    version='0.1.1',
 
     description='Saliency methods for TensorFlow',
     long_description=long_description,
@@ -67,7 +67,7 @@ setup(
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    packages=['saliency'],
+    packages=find_packages(),
     #package_dir={'': '.'},
     #packages=[''],
 


### PR DESCRIPTION
This bumps up the pip version to 0.1.1 and provides a stable pip package.

This fixes a bug where the core and tf1 subpackages weren't included in the wheel installation.