### PR TITLE
Bump version to 0.1.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.1.1',
+    version='0.1.2',
 
     description='Framework-agnostic saliency methods',
     long_description=long_description,


### PR DESCRIPTION
Updates between version 0.1.1 and 0.1.2:

- Updated README and description in setup.py
- Fixed validate_xy_tensor_shape in saliency.tf1 to work when v2_tensor_shape is disabled.