### PR TITLE
Remove ShowDivergingImage from example notebooks

### DIFF
--- a/Examples_core.ipynb
+++ b/Examples_core.ipynb
@@ -91,19 +91,6 @@
     "  P.imshow(im, cmap='inferno')\n",
     "  P.title(title)\n",
     "\n",
-    "def ShowDivergingImage(grad, title='', percentile=99, ax=None):  \n",
-    "  if ax is None:\n",
-    "    fig, ax = P.subplots()\n",
-    "  else:\n",
-    "    fig = ax.figure\n",
-    "  \n",
-    "  P.axis('off')\n",
-    "  divider = make_axes_locatable(ax)\n",
-    "  cax = divider.append_axes('right', size='5%', pad=0.05)\n",
-    "  im = ax.imshow(grad, cmap=P.cm.coolwarm, vmin=-1, vmax=1)\n",
-    "  fig.colorbar(im, cax=cax, orientation='vertical')\n",
-    "  P.title(title)\n",
-    "\n",
     "def LoadImage(file_path):\n",
     "  im = PIL.Image.open(file_path)\n",
     "  im = im.resize((224,224))\n",
@@ -617,7 +604,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -631,7 +618,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.8.7"
   }
  },
  "nbformat": 4,

--- a/Examples_pytorch.ipynb
+++ b/Examples_pytorch.ipynb
@@ -79,19 +79,6 @@
     "    P.imshow(im, cmap='inferno')\n",
     "    P.title(title)\n",
     "\n",
-    "def ShowDivergingImage(grad, title='', percentile=99, ax=None):  \n",
-    "    if ax is None:\n",
-    "        fig, ax = P.subplots()\n",
-    "    else:\n",
-    "        fig = ax.figure\n",
-    "  \n",
-    "    P.axis('off')\n",
-    "    divider = make_axes_locatable(ax)\n",
-    "    cax = divider.append_axes('right', size='5%', pad=0.05)\n",
-    "    im = ax.imshow(grad, cmap=P.cm.coolwarm, vmin=-1, vmax=1)\n",
-    "    fig.colorbar(im, cax=cax, orientation='vertical')\n",
-    "    P.title(title)\n",
-    "\n",
     "def LoadImage(file_path):\n",
     "    im = PIL.Image.open(file_path)\n",
     "    im = im.resize((299, 299))\n",
@@ -634,7 +621,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/Examples_tf1.ipynb
+++ b/Examples_tf1.ipynb
@@ -93,19 +93,6 @@
     "  P.imshow(im, cmap='inferno')\n",
     "  P.title(title)\n",
     "\n",
-    "def ShowDivergingImage(grad, title='', percentile=99, ax=None):  \n",
-    "  if ax is None:\n",
-    "    fig, ax = P.subplots()\n",
-    "  else:\n",
-    "    fig = ax.figure\n",
-    "  \n",
-    "  P.axis('off')\n",
-    "  divider = make_axes_locatable(ax)\n",
-    "  cax = divider.append_axes('right', size='5%', pad=0.05)\n",
-    "  im = ax.imshow(grad, cmap=P.cm.coolwarm, vmin=-1, vmax=1)\n",
-    "  fig.colorbar(im, cax=cax, orientation='vertical')\n",
-    "  P.title(title)\n",
-    "\n",
     "def LoadImage(file_path):\n",
     "  im = PIL.Image.open(file_path)\n",
     "  im = np.asarray(im)\n",
@@ -684,7 +671,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -698,7 +685,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.8.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Because the function is unused, remove the ShowDivergingImage function from the example notes.