### PR TITLE
Change display of regions percentage

### DIFF
--- a/Examples_core.ipynb
+++ b/Examples_core.ipynb
@@ -347,7 +347,7 @@
     "ShowHeatMap(xrai_attributions, title='XRAI Heatmap', ax=P.subplot(ROWS, COLS, 2))\n",
     "\n",
     "# Show most salient 30% of the image\n",
-    "mask = xrai_attributions > np.percentile(xrai_attributions, 70)\n",
+    "mask = xrai_attributions >= np.percentile(xrai_attributions, 70)\n",
     "im_mask = np.array(im_orig)\n",
     "im_mask[~mask] = 0\n",
     "ShowImage(im_mask, title='Top 30%', ax=P.subplot(ROWS, COLS, 3))"
@@ -392,7 +392,7 @@
     "ShowHeatMap(xrai_attributions_fast, title='XRAI Heatmap', ax=P.subplot(ROWS, COLS, 2))\n",
     "\n",
     "# Show most salient 30% of the image\n",
-    "mask = xrai_attributions_fast > np.percentile(xrai_attributions_fast, 70)\n",
+    "mask = xrai_attributions_fast >= np.percentile(xrai_attributions_fast, 70)\n",
     "im_mask = np.array(im_orig)\n",
     "im_mask[~mask] = 0\n",
     "ShowImage(im_mask, 'Top 30%', ax=P.subplot(ROWS, COLS, 3))"

--- a/Examples_pytorch.ipynb
+++ b/Examples_pytorch.ipynb
@@ -364,7 +364,7 @@
     "ShowHeatMap(xrai_attributions, title='XRAI Heatmap', ax=P.subplot(ROWS, COLS, 2))\n",
     "\n",
     "# Show most salient 30% of the image\n",
-    "mask = xrai_attributions > np.percentile(xrai_attributions, 70)\n",
+    "mask = xrai_attributions >= np.percentile(xrai_attributions, 70)\n",
     "im_mask = np.array(im_orig)\n",
     "im_mask[~mask] = 0\n",
     "ShowImage(im_mask, title='Top 30%', ax=P.subplot(ROWS, COLS, 3))"
@@ -409,7 +409,7 @@
     "ShowHeatMap(xrai_attributions_fast, title='XRAI Heatmap', ax=P.subplot(ROWS, COLS, 2))\n",
     "\n",
     "# Show most salient 30% of the image\n",
-    "mask = xrai_attributions_fast > np.percentile(xrai_attributions_fast, 70)\n",
+    "mask = xrai_attributions_fast >= np.percentile(xrai_attributions_fast, 70)\n",
     "im_mask = np.array(im_orig)\n",
     "im_mask[~mask] = 0\n",
     "ShowImage(im_mask, 'Top 30%', ax=P.subplot(ROWS, COLS, 3))"

--- a/Examples_tf1.ipynb
+++ b/Examples_tf1.ipynb
@@ -411,7 +411,7 @@
     "ShowHeatMap(xrai_attributions, title='XRAI Heatmap', ax=P.subplot(ROWS, COLS, 2))\n",
     "\n",
     "# Show most salient 30% of the image\n",
-    "mask = xrai_attributions > np.percentile(xrai_attributions, 70)\n",
+    "mask = xrai_attributions >= np.percentile(xrai_attributions, 70)\n",
     "im_mask = np.array(im)\n",
     "im_mask[~mask] = 0\n",
     "ShowImage(im_mask, title='Top 30%', ax=P.subplot(ROWS, COLS, 3))"
@@ -456,7 +456,7 @@
     "ShowHeatMap(xrai_attributions_fast, title='XRAI Heatmap', ax=P.subplot(ROWS, COLS, 2))\n",
     "\n",
     "# Show most salient 30% of the image\n",
-    "mask = xrai_attributions_fast > np.percentile(xrai_attributions_fast, 70)\n",
+    "mask = xrai_attributions_fast >= np.percentile(xrai_attributions_fast, 70)\n",
     "im_mask = np.array(im)\n",
     "im_mask[~mask] = 0\n",
     "ShowImage(im_mask, 'Top 30%', ax=P.subplot(ROWS, COLS, 3))"


### PR DESCRIPTION
When displaying some percentage of XRAI regions, the attributions must be superior **or equal** to the percentile value.
An example is to display 100% of regions (i.e. complete image), with '=' sign the script yields the whole image, without the sign some regions are still masked.