### PR TITLE
Resolve deprecation of selem argument (now footprint) in skimage.morphology.dilation

### DIFF
--- a/saliency/core/xrai.py
+++ b/saliency/core/xrai.py
@@ -122,8 +122,8 @@ def _get_segments_felzenszwalb(im,
       segs.append(seg)
   masks = _unpack_segs_to_masks(segs)
   if dilation_rad:
-    selem = disk(dilation_rad)
-    masks = [dilation(mask, footprint=selem) for mask in masks]
+    footprint = disk(dilation_rad)
+    masks = [dilation(mask, footprint=footprint) for mask in masks]
   return masks
 
 

--- a/saliency/core/xrai.py
+++ b/saliency/core/xrai.py
@@ -123,7 +123,7 @@ def _get_segments_felzenszwalb(im,
   masks = _unpack_segs_to_masks(segs)
   if dilation_rad:
     selem = disk(dilation_rad)
-    masks = [dilation(mask, selem=selem) for mask in masks]
+    masks = [dilation(mask, footprint=selem) for mask in masks]
   return masks
 
 


### PR DESCRIPTION
Recent versions of scikit-image have completely deprecated the `selem` argument in favor of `dilation`:

[skimage.morphology.dilation](https://scikit-image.org/docs/stable/api/skimage.morphology.html#skimage.morphology.dilation)
[Complete deprecation of selem parameter](https://github.com/scikit-image/scikit-image/pull/6583/commits/7430c415ccdf716c1aca7226f03ede85e12e1ba9)

This minor patch to [xrai.py](https://github.com/PAIR-code/saliency/blob/master/saliency/core/xrai.py#L126) resolves the issue on line 126.